### PR TITLE
SEO: shorten title suffix, sharpen page titles, complete church schema

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- Primary Meta Tags -->
-    {% if page.title and page.title != 'Home' %}{% assign page_title = page.title | append: ' - ' | append: site.title %}{% else %}{% assign page_title = site.title | append: ' (1689)' %}{% endif %}
+    {% if page.title and page.title != 'Home' %}
+      {% if page.layout == 'sermon' and page.series and page.series != page.title %}
+        {% assign page_title = page.title | append: ' (' | append: page.series | append: ') | ' | append: site.church.name %}
+      {% else %}
+        {% assign page_title = page.title | append: ' | ' | append: site.church.name %}
+      {% endif %}
+    {% else %}
+      {% assign page_title = site.title | append: ' (1689)' %}
+    {% endif %}
     <title itemprop="name">{{ page_title }}</title>
     <meta name="title" content="{{ page_title }}">
     <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" itemprop="description">
@@ -78,6 +86,8 @@
       "description": "{{ site.description }}",
       "url": "{{ site.url }}",
       "email": "{{ site.email }}",
+      {% if site.church.phone and site.church.phone != "(865) 555-0123" %}"telephone": "{{ site.church.phone }}",
+      {% endif %}"priceRange": "Free",
       "address": {
         "@type": "PostalAddress",
         "streetAddress": "{{ site.church.address.street }}",
@@ -131,7 +141,7 @@
     {% endif %}
 
     <!-- Enhanced schema for sermons listing page -->
-    {% if page.title == "Sermons" and page.layout == "default" %}
+    {% if page.url == "/sermons/" and page.layout == "default" %}
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/beliefs.md
+++ b/beliefs.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Our Beliefs"
+title: "1689 Confession & Reformed Baptist Beliefs"
 description: "Our Reformed Baptist beliefs and doctrinal distinctives based on the London Baptist Confession of 1689. Learn what Saints Church in Knoxville, TN believes about Scripture, salvation, baptism, and church life."
 permalink: /beliefs/
 data_key: beliefs

--- a/sermons.md
+++ b/sermons.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Sermons"
+title: "Sermons & Expository Preaching"
 description: "Listen to expository sermons from Saints Church in Knoxville, TN. Reformed Baptist preaching through books of the Bible verse-by-verse, available on Apple Podcasts, Spotify, and Overcast."
 permalink: /sermons/
 ---


### PR DESCRIPTION
## Summary

90-day GSC audit (151 clicks / 2,887 impressions / 5.23% CTR / pos 10.8) surfaced two patterns dragging down CTR: long brand-suffix truncation across 5 of 7 audited pages, and per-page titles that didn't match the actual search intent driving impressions. This PR fixes the title pipeline and tightens the Church schema using only data already in the repo — no body copy or meta descriptions changed.

## What this PR changes

| Page | Before | After | Length |
|------|--------|-------|--------|
| / | Saints Church \| Reformed Baptist Church in Knoxville, TN (1689) | *(unchanged)* | 63 |
| /beliefs/ | Our Beliefs - Saints Church \| Reformed Baptist Church in Knoxville, TN (70) | 1689 Confession & Reformed Baptist Beliefs \| Saints Church | 59 |
| /sermons/ | Sermons - Saints Church \| Reformed Baptist Church in Knoxville, TN (66) | Sermons & Expository Preaching \| Saints Church | 47 |
| /about/ | About - Saints Church \| Reformed Baptist Church in Knoxville, TN (64) | About \| Saints Church | 22 |
| /resources/ | Resources - Saints Church \| Reformed Baptist Church in Knoxville, TN (68) | Resources \| Saints Church | 26 |
| /sermons/galatians-211-21/ | Galatians 2:11-21 - Saints Church \| Reformed Baptist Church in Knoxville, TN (78) | Galatians 2:11-21 (Galatians) \| Saints Church | 46 |

Also:
- `Church` schema now sets `"priceRange": "Free"` (Google recommends for places of worship; helps knowledge-panel readiness).
- Conditional `"telephone"` block is wired up but **does not render** until the placeholder `(865) 555-0123` in `_config.yml` is replaced with the real number — see "Follow-ups" below.
- The `/sermons/` `CollectionPage` schema conditional was rewritten from `page.title == \"Sermons\"` → `page.url == \"/sermons/\"` so the title rewrite doesn't accidentally drop the schema.

## Why these specifically

From the 90-day GSC pull:

- **#1 (suffix):** every non-home page appended a 60-char brand suffix, truncating the page topic out of view. Largest expected lift: ~+15–25 clicks/mo across the whole site.
- **#2 (/beliefs/):** ranked pos 6.7 / 256 imp / 0.39% CTR. Page surfaced for "1689 baptist church near me", "1689 churches near me", "reformer church", "reformed bible church", "reformed church knoxville tn" — none of those terms appeared in the visible title.
- **#3 (/sermons/):** pos 6.7 / 328 imp / 1.83% CTR — far below expected for that position.
- **#4 (sermon detail titles):** ~30–100 imp/sermon with most at 0 clicks; series context now survives truncation.
- **#5 (schema):** baseline `Church` schema was solid but missing `priceRange` and `telephone`.

## Test plan

- [x] `bundle exec jekyll build` succeeds locally
- [x] Verified rendered titles on /, /beliefs/, /sermons/, /about/, /resources/, /sermons/galatians-211-21/
- [x] Verified all titles ≤ 60 chars (homepage at 63 is intentional)
- [x] Verified `CollectionPage` schema still rendered on /sermons/ (2 JSON-LD blocks)
- [x] Verified `priceRange: Free` rendered in Church schema sitewide
- [x] Verified `telephone` correctly omitted while phone is placeholder
- [ ] Spot-check on staging / preview deploy
- [ ] Validate schema with https://validator.schema.org/ after deploy

## Follow-ups (not in this PR)

1. Replace the placeholder phone `(865) 555-0123` in `_config.yml` with the real church number — the schema's `telephone` field will then auto-render.
2. Add real social profile URLs to the schema's `sameAs` array (currently only Apple/Spotify podcast links).
3. PageSpeed Insights data was not collected — quota was exhausted on the GCP project used for the audit. Set `PAGESPEED_API_KEY` and re-run for Core Web Vitals before deciding on performance work.
4. Brand-authority lever for the homepage's pos 11 ranking on "saints church" (own brand) — needs links, not titles. Local Knoxville directories, denominational listings, partner-church references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)