### PR TITLE
Repair the PR review workflow and guard unknown preachers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,15 +33,15 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # pinned: the action's own default tracked a model that has since been retired
+          claude_args: "--model claude-sonnet-5"
 
           # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
@@ -55,7 +55,7 @@ jobs:
           # use_sticky_comment: true
           
           # Optional: Customize review based on file types
-          # direct_prompt: |
+          # prompt: |
           #   Review this PR focusing on:
           #   - For TypeScript files: Type safety and proper interface usage
           #   - For API endpoints: Security, input validation, and error handling
@@ -63,7 +63,7 @@ jobs:
           #   - For tests: Coverage, edge cases, and test quality
           
           # Optional: Different prompts for different authors
-          # direct_prompt: |
+          # prompt: |
           #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}

--- a/_includes/pastor-image.html
+++ b/_includes/pastor-image.html
@@ -4,12 +4,11 @@ class, loading ("eager" above the fold). The img carries the low-res base and
 the source steps up to the WebP the browser actually paints.
 {%- endcomment -%}
 {% assign preacher = site.data.preachers | where: "key", include.preacher | first %}
-{% unless preacher %}
-  {% assign preacher = site.data.preachers | first %}
-{% endunless %}
 {% assign px = include.px | default: 128 %}
 {% assign image_class = include.class | default: "size-32 rounded-full" %}
 
+{% comment %}a preacher absent from preachers.yml gets no portrait, never someone else's{% endcomment %}
+{% if preacher %}
 <picture class="block">
   <source
     type="image/webp"
@@ -25,3 +24,4 @@ the source steps up to the WebP the browser actually paints.
     decoding="async"
   />
 </picture>
+{% endif %}

--- a/_layouts/preacher.html
+++ b/_layouts/preacher.html
@@ -4,6 +4,7 @@ layout: default
 
 {% assign preacher_sermons = site.posts | where: "pastor", page.preacher | sort: "date" %}
 {% assign preacher = site.data.preachers | where: "key", page.preacher | first %}
+{% assign preacher_name = preacher.name | default: page.preacher | remove: "Pastor " %}
 
 <script type="application/ld+json">
 {
@@ -50,7 +51,7 @@ layout: default
       <li aria-hidden="true">&middot;</li>
       <li><a href="/sermons/preachers/" class="text-stone-500 transition-colors duration-200 hover:text-stone-900 dark:text-stone-400 dark:hover:text-white">Preachers</a></li>
       <li aria-hidden="true">&middot;</li>
-      <li>{{ preacher.name }}</li>
+      <li>{{ preacher_name }}</li>
     </ol>
   </nav>
 
@@ -58,10 +59,12 @@ layout: default
     <div class="flex items-center gap-5">
       {% include pastor-image.html class="size-16 rounded-full" px=64 loading="eager" preacher=page.preacher %}
       <div>
-        <h1 itemprop="name" class="font-display text-5xl leading-none font-bold tracking-tight text-stone-900 sm:text-6xl dark:text-white">{{ preacher.name }}</h1>
+        <h1 itemprop="name" class="font-display text-5xl leading-none font-bold tracking-tight text-stone-900 sm:text-6xl dark:text-white">{{ preacher_name }}</h1>
         <p class="mt-4 flex flex-wrap items-center gap-3 text-base text-stone-500 tabular-nums dark:text-stone-400">
-          <span>{{ preacher.role }}</span>
-          <span aria-hidden="true" class="text-stone-300 dark:text-stone-600">&middot;</span>
+          {% if preacher.role %}
+            <span>{{ preacher.role }}</span>
+            <span aria-hidden="true" class="text-stone-300 dark:text-stone-600">&middot;</span>
+          {% endif %}
           <span>{{ preacher_sermons.size }} sermon{% unless preacher_sermons.size == 1 %}s{% endunless %}</span>
         </p>
       </div>

--- a/_layouts/sermon.html
+++ b/_layouts/sermon.html
@@ -3,6 +3,7 @@ layout: default
 ---
 
 {% assign preacher = site.data.preachers | where: "key", page.pastor | first %}
+{% assign preacher_name = preacher.name | default: page.pastor | remove: "Pastor " %}
 {% comment %}page.previous is collection order, so a same-day sermon would read as last Sunday{% endcomment %}
 {% assign current_day = page.date | date: "%Y%m%d" | plus: 0 %}
 {% assign newer_first = site.posts | where: "category", "sermon" | sort: "date" | reverse %}
@@ -54,7 +55,7 @@ layout: default
           {% if page.pastor %}
             <address itemscope itemtype="https://schema.org/Person" class="flex items-center gap-3 not-italic">
               {% include pastor-image.html class="size-8 rounded-full" px=32 loading="eager" preacher=page.pastor %}
-              <a href="/sermons/preachers/{{ page.pastor | slugify }}/" itemprop="name" class="text-white/90 transition-colors duration-200 hover:text-white">{{ preacher.name }}, {{ preacher.role }}</a>
+              <a href="/sermons/preachers/{{ page.pastor | slugify }}/" itemprop="name" class="text-white/90 transition-colors duration-200 hover:text-white">{{ preacher_name }}{% if preacher.role %}, {{ preacher.role }}{% endif %}</a>
             </address>
             <span aria-hidden="true" class="text-white/40">&middot;</span>
           {% endif %}

--- a/_layouts/taxonomy-index.html
+++ b/_layouts/taxonomy-index.html
@@ -45,11 +45,12 @@ layout: default
       {% assign all_preachers = all_sermons | map: "pastor" | compact | uniq | sort %}
       {% for preacher_key in all_preachers %}
         {% assign preacher = site.data.preachers | where: "key", preacher_key | first %}
+        {% assign preacher_name = preacher.name | default: preacher_key | remove: "Pastor " %}
         {% assign preacher_posts = all_sermons | where: "pastor", preacher_key %}
         {% assign preacher_latest = preacher_posts | sort: "date" | last %}
         <a href="/sermons/preachers/{{ preacher_key | slugify }}/" class="-mx-4 flex flex-wrap items-center gap-x-6 gap-y-2.5 rounded-lg border-b border-stone-900/5 px-4 py-6 transition-colors duration-200 hover:bg-stone-900/3 dark:border-white/5 dark:hover:bg-white/5">
           {% include pastor-image.html class="size-12 shrink-0 rounded-full" px=48 preacher=preacher_key %}
-          <h2 class="min-w-44 flex-1 font-display text-3xl leading-tight font-bold tracking-tight text-stone-900 dark:text-white">{{ preacher.name }}</h2>
+          <h2 class="min-w-44 flex-1 font-display text-3xl leading-tight font-bold tracking-tight text-stone-900 dark:text-white">{{ preacher_name }}</h2>
           <span class="min-w-24 text-sm text-stone-500 tabular-nums dark:text-stone-400">{{ preacher_posts.size }} sermon{% unless preacher_posts.size == 1 %}s{% endunless %}</span>
           <span class="min-w-64 text-sm text-stone-500 tabular-nums sm:text-right dark:text-stone-400">Latest: {{ preacher_latest.title | escape }}</span>
         </a>


### PR DESCRIPTION
Two unrelated fixes that both needed a PR to prove out.

**Review workflow.** `claude-code-review.yml` pinned nothing, so it inherited the action's default model — `claude-sonnet-4-20250514`, since retired. Every PR since May failed with a 404. Now pinned to `anthropics/claude-code-action@v1` with `claude_args: "--model claude-sonnet-5"`. v1 also renamed `direct_prompt` to `prompt`, so that rename is included; without it the version bump would have broken differently. This PR is itself the test.

**Unknown preacher (review finding #12).** `pastor-image.html` fell back to `site.data.preachers | first` when a preacher was absent from `preachers.yml`, so a new preacher arriving from the feed rendered a blank name beside *Nate's portrait*. Now the name falls back to the feed value and no portrait renders at all.

Verified with a temporary probe post using an unknown preacher, then removed:

| surface | before | after |
|---|---|---|
| sermon hero | blank name, wrong portrait | `Rev Unknown Person`, no portrait |
| preacher page | blank `<h1>`, wrong portrait | `Rev Unknown Person`, role omitted |
| preachers index | blank entry | `Rev Unknown Person` |

Known preachers unchanged: 120 avatars, 0 missing alt, roles still shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011j9kpmEJCZmiPhprYSf88j